### PR TITLE
removing constant TL_ASSETS_URL

### DIFF
--- a/src/system/modules/jquery-ui-tabs/templates/j_ui_tabs.html5
+++ b/src/system/modules/jquery-ui-tabs/templates/j_ui_tabs.html5
@@ -1,7 +1,7 @@
 
-<?php 
-	$GLOBALS['TL_JAVASCRIPT'][] = TL_ASSETS_URL . 'assets/jquery-ui-tabs/jquery-ui-tabs.js|static'; 
-	$GLOBALS['TL_JAVASCRIPT'][] = TL_ASSETS_URL . 'assets/jquery-ui-tabs/core.js|static'; 
+<?php
+	$GLOBALS['TL_JAVASCRIPT'][] = 'assets/jquery-ui-tabs/jquery-ui-tabs.js|static';
+	$GLOBALS['TL_JAVASCRIPT'][] = 'assets/jquery-ui-tabs/core.js|static';
 ?>
 <script>
 	(function($) {

--- a/src/system/modules/jquery-ui-tabs/templates/j_ui_tabs.xhtml
+++ b/src/system/modules/jquery-ui-tabs/templates/j_ui_tabs.xhtml
@@ -1,7 +1,7 @@
 
-<?php 
-	$GLOBALS['TL_JAVASCRIPT'][] = TL_ASSETS_URL . 'assets/jquery-ui-tabs/jquery-ui-tabs.js|static'; 
-	$GLOBALS['TL_JAVASCRIPT'][] = TL_ASSETS_URL . 'assets/jquery-ui-tabs/core.js|static'; 
+<?php
+	$GLOBALS['TL_JAVASCRIPT'][] = 'assets/jquery-ui-tabs/jquery-ui-tabs.js|static';
+	$GLOBALS['TL_JAVASCRIPT'][] = 'assets/jquery-ui-tabs/core.js|static';
 ?>
 <script type="text/javascript">
 	/* <![CDATA[ */


### PR DESCRIPTION
Hey,
when you are push javascripts to the global you don't now use the assets constants.

This make an error by using assets url.
